### PR TITLE
Public API for symbol size estimation

### DIFF
--- a/aztec_code_generator.py
+++ b/aztec_code_generator.py
@@ -12,7 +12,13 @@
 
 import math
 import numbers
-from PIL import Image, ImageDraw
+import sys
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:
+    Image = ImageDraw = None
+    missing_pil = sys.exc_info()
 
 try:
     from StringIO import StringIO
@@ -488,6 +494,8 @@ class AztecCode(object):
         :param filename: output image filename.
         :param module_size: barcode module size in pixels.
         """
+        if ImageDraw is None:
+            raise missing_pil[0], missing_pil[1], missing_pil[2]
         image = Image.new('RGB', (self.size * module_size, self.size * module_size), 'white')
         image_draw = ImageDraw.Draw(image)
         for y in range(self.size):
@@ -763,7 +771,10 @@ def main():
     data = 'Aztec Code 2D :)'
     aztec_code = AztecCode(data)
     aztec_code.print_out()
-    aztec_code.save('aztec_code.png', 4)
+    if ImageDraw is None:
+        print 'PIL is not installed, cannot generate PNG'
+    else:
+        aztec_code.save('aztec_code.png', 4)
     print('Aztec Code info: {0}x{0} {1}'.format(aztec_code.size, '(compact)' if aztec_code.compact else ''))
 
 

--- a/aztec_code_generator.py
+++ b/aztec_code_generator.py
@@ -452,6 +452,26 @@ def get_config_from_table(size, compact):
         raise Exception('Failed to find config with size and compactness flag')
     return config
 
+def find_suitable_matrix_size(data):
+    """ Find suitable matrix size
+    Raise an exception if suitable size is not found
+
+    :param data: data to encode
+    :return: (size, compact) tuple
+    """
+    optimal_sequence = find_optimal_sequence(data)
+    out_bits = optimal_sequence_to_bits(optimal_sequence)
+    for (size, compact) in sorted(table.keys()):
+        config = get_config_from_table(size, compact)
+        bits = config.get('bits')
+        # error correction percent
+        ec_percent = 23  # recommended: 23% of symbol capacity plus 3 codewords
+        # calculate minimum required number of bits
+        required_bits_count = int(math.ceil(len(out_bits) * 100.0 / (
+            100 - ec_percent) + 3 * 100.0 / (100 - ec_percent)))
+        if required_bits_count < bits:
+            return size, compact
+    raise Exception('Data too big to fit in one Aztec code!')
 
 class AztecCode(object):
     """
@@ -475,7 +495,7 @@ class AztecCode(object):
                 raise Exception(
                     'Given size and compact values (%s, %s) are not found in sizes table!' % (size, compact))
         else:
-            self.size, self.compact = self.__find_suitable_matrix_size()
+            self.size, self.compact = find_suitable_matrix_size(self.data)
         self.__create_matrix()
         self.__encode_data()
 
@@ -510,26 +530,6 @@ class AztecCode(object):
         """ Print out Aztec code matrix """
         for line in self.matrix:
             print(''.join(x for x in line))
-
-    def __find_suitable_matrix_size(self):
-        """ Find suitable matrix size
-        Raise an exception if suitable size is not found
-
-        :return: (size, compact) tuple
-        """
-        optimal_sequence = find_optimal_sequence(self.data)
-        out_bits = optimal_sequence_to_bits(optimal_sequence)
-        for (size, compact) in sorted(table.keys()):
-            config = get_config_from_table(size, compact)
-            bits = config.get('bits')
-            # error correction percent
-            ec_percent = 23  # recommended
-            # calculate minimum required number of bits
-            required_bits_count = int(math.ceil(len(out_bits) * 100.0 / (
-                100 - ec_percent) + 3 * 100.0 / (100 - ec_percent)))
-            if required_bits_count < bits:
-                return size, compact
-        raise Exception('Data too big to fit in one Aztec code!')
 
     def __add_finder_pattern(self):
         """ Add bulls-eye finder pattern """


### PR DESCRIPTION
I am going to use Aztec codes with ReportLab PDF generation.
For that I need these two changes to the module:

1. No PIL requirement.  (The symbol would be generated using ReportLab drawing primitives.)

2. Public API for symbol size estimation, to reserve a space in page layout before the symbol is actually generated.