### PR TITLE
raise Exception compatible with Python3 (PEP-3109)

### DIFF
--- a/aztec_code_generator.py
+++ b/aztec_code_generator.py
@@ -515,7 +515,9 @@ class AztecCode(object):
         :param module_size: barcode module size in pixels.
         """
         if ImageDraw is None:
-            raise missing_pil[0], missing_pil[1], missing_pil[2]
+            exc = missing_pil[0](missing_pil[1])
+            exc.__traceback__ = missing_pil[2]
+            raise exc
         image = Image.new('RGB', (self.size * module_size, self.size * module_size), 'white')
         image_draw = ImageDraw.Draw(image)
         for y in range(self.size):


### PR DESCRIPTION
Trying to use aztec_code_generator with Python3 I discovered a small incompatibility. Tested on Python 3.6.3 and 2.7.14.