### PR TITLE
Added support for SVG files in the AztecCode.save method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,27 @@ PIL - Python Imaging Library (or Pillow)
 
 
 ## Usage:
+This code will generate an image file "aztec_code.png" with the Aztec Code that contains "Aztec Code 2D :)" text:
 ```python
 data = 'Aztec Code 2D :)'
 aztec_code = AztecCode(data)
 aztec_code.save('aztec_code.png', module_size=4)
 ```
 
-This code will generate an image file "aztec_code.png" with the Aztec Code that contains "Aztec Code 2D :)" text.
-
 ![Aztec Code](https://1.bp.blogspot.com/-OZIo4dGwAM4/V7BaYoBaH2I/AAAAAAAAAwc/WBdTV6osTb4TxNf2f6v7bCfXM4EuO4OdwCLcB/s1600/aztec_code.png "Aztec Code with data")
 
+The generator supports SVG images, but without the upper text. In this case the `module_size` parameter has no effect and can be ommited, as the SVG images are scalable without loss of quality:
+```python
+aztec_code = AztecCode('the data to store')
+aztec_code.save('aztec_code.svg')
+```
+
+This code will print out resulting 19x19 (compact) Aztec Code to the standard output:
 ```python
 data = 'Aztec Code 2D :)'
 aztec_code = AztecCode(data)
 aztec_code.print_out()
 ```
-
-This code will print out resulting 19x19 (compact) Aztec Code to the standard output.
 
 ```
       ##  # ## ####


### PR DESCRIPTION
I added a new class `SVGFactory`, which allows to create SVG images based on the 2d matrix. The method `SVGFactory.save` is called in the `AztecCode.save` method if the file name ends with `.svg`. All of the code was covered by tests. Please find the example code below. The advantage of SVG is that it scales well without any loss of quality.

Unfortunately, I didn't add the option to provide text above the image, because we would need to attach heavy font files to each image (or provide links to fonts which is also not always possible). Also, I'm not sure if it would be possible to easily wrap long texts

![aztec_code](https://github.com/user-attachments/assets/e3eb2785-69a7-4a7c-856e-7cbc9b000845)

```sh
py.test --verbose

test_aztec_code_generator.py::Test::test_find_optimal_sequence PASSED                                                            [ 12%]
test_aztec_code_generator.py::Test::test_get_data_codewords PASSED                                                               [ 25%]
test_aztec_code_generator.py::Test::test_optimal_sequence_to_bits PASSED                                                         [ 37%]
test_aztec_code_generator.py::Test::test_reed_solomon PASSED                                                                     [ 50%]
test_aztec_code_generator.py::TestSvgFactory::test_create_svg PASSED                                                             [ 62%]
test_aztec_code_generator.py::TestSvgFactory::test_init PASSED                                                                   [ 75%]
test_aztec_code_generator.py::TestSvgFactory::test_save PASSED                                                                   [ 87%]
test_aztec_code_generator.py::TestAztecCode::test_save_should_support_svg PASSED                                                 [100%]

========================================================== 8 passed in 0.09s ==========================================================
```